### PR TITLE
Change timing of destroy table

### DIFF
--- a/pysqldf/sqldf.py
+++ b/pysqldf/sqldf.py
@@ -59,14 +59,14 @@ class SQLDF(object):
             returns DataFrame else None.
         """
         tables = self._extract_table_names(query)
-        for table in tables:
-            if table not in self.env:
-                raise Exception("%s not found" % table)
-            df = self.env[table]
-            df = self._ensure_data_frame(df, table)
-            self._write_table(table, df)
-
         try:
+            for table in tables:
+                if table not in self.env:
+                    raise Exception("%s not found" % table)
+                df = self.env[table]
+                df = self._ensure_data_frame(df, table)
+                self._write_table(table, df)
+
             result = read_sql(query, self.conn, index_col=None)
             if "index" in result:
                 del result["index"]

--- a/tests/sqldf.py
+++ b/tests/sqldf.py
@@ -194,6 +194,15 @@ class SQLDFTest(unittest.TestCase):
         sqldf = SQLDF(locals())
         self.assertRaises(Exception, lambda: sqldf._write_table("tbl", df))
 
+    def test_write_table_method_garbage_table(self):
+        df = [[1, 2], [3, [4]]]
+        sqldf = SQLDF(locals())
+        self.assertRaises(Exception, lambda: sqldf._write_table("tbl", df))
+        # table destroyed
+        cursor = sqldf.conn.cursor()
+        tablemaster = list(cursor.execute("select * from sqlite_master where type='table';"))
+        self.assertEqual(tablemaster, [])
+
     def test_del_table_method(self):
         sqldf = SQLDF(locals())
         cursor = sqldf.conn.cursor()


### PR DESCRIPTION
When table data is invalid form, table lives in sqlite memory.